### PR TITLE
Extract pep257 docstring errors

### DIFF
--- a/lib/linter-flake8.coffee
+++ b/lib/linter-flake8.coffee
@@ -13,7 +13,7 @@ class LinterFlake8 extends Linter
 
   # A regex pattern used to extract information from the executable's output.
   regex:
-    '(.*?):(?<line>\\d+):(?<col>\\d+): (?<message>((?<error>E11|E9)|(?<warning>W|E|F4|F84|N*|C)|F)\\d+ .*?)\r?\n'
+    '(.*?):(?<line>\\d+):(?<col>\\d+): (?<message>((?<error>E11|E9)|(?<warning>W|E|F4|F84|N*|C|D)|F)\\d+ .*?)\r?\n'
 
   constructor: (editor)->
     super(editor)


### PR DESCRIPTION
This updates the error regex to match pep257 (D###) errors.

It's useful for users of the [flake8-docstrings][1] plugin, which adds pep257 support to flake8. (An alternative might be to relax the expression.)

[1]: https://gitlab.com/pycqa/flake8-docstrings/blob/master/README.rst