### PR TITLE
Use project config (Fix for #8)

### DIFF
--- a/lib/linter-flake8.coffee
+++ b/lib/linter-flake8.coffee
@@ -45,7 +45,7 @@ class LinterFlake8 extends Linter
     atom.config.unobserve 'linter-flake8.hangClosing'
 
   updateCommand: ->
-    cmd = 'flake8'
+    cmd = ['flake8']
     maxLineLength = atom.config.get 'linter-flake8.maxLineLength'
     errorCodes = atom.config.get 'linter-flake8.ignoreErrorCodes'
     maxComplexity = atom.config.get 'linter-flake8.maxComplexity'
@@ -53,19 +53,19 @@ class LinterFlake8 extends Linter
     hangClosing = atom.config.get 'linter-flake8.hangClosing'
 
     if maxLineLength
-      cmd = "#{cmd} --max-line-length=#{maxLineLength}"
+      cmd.push '--max-line-length', maxLineLength
 
     if errorCodes and errorCodes.length > 0
-      cmd += " --ignore=#{errorCodes.toString()}"
+      cmd.push '--ignore', errorCodes.toString()
 
     if maxComplexity
-      cmd += " --max-complexity=#{maxComplexity}"
+      cmd.push '--max-complexity', maxComplexity
 
     if selectErrors
-      cmd += " --select=#{selectErrors.toString()}"
+      cmd.push '--select', selectErrors.toString()
 
     if hangClosing
-      cmd += " --hang-closing"
+      cmd.push '--hang-closing'
 
     @cmd = cmd
 

--- a/lib/linter-flake8.coffee
+++ b/lib/linter-flake8.coffee
@@ -1,6 +1,7 @@
 linterPath = atom.packages.getLoadedPackage("linter").path
 
 Linter = require "#{linterPath}/lib/linter"
+{findFile} = require "#{linterPath}/lib/utils"
 
 class LinterFlake8 extends Linter
   @syntax: ['source.python']
@@ -17,6 +18,8 @@ class LinterFlake8 extends Linter
 
   constructor: (editor)->
     super(editor)
+
+    @configFile = findFile @cwd, ['setup.cfg', 'tox.ini', '.pep8']
 
     atom.config.observe 'linter-flake8.executableDir', =>
       @executablePath = atom.config.get 'linter-flake8.executableDir'
@@ -54,6 +57,9 @@ class LinterFlake8 extends Linter
 
     if maxLineLength
       cmd.push '--max-line-length', maxLineLength
+
+    if @configFile
+      cmd.push '--config', @configFile
 
     if errorCodes and errorCodes.length > 0
       cmd.push '--ignore', errorCodes.toString()


### PR DESCRIPTION
This will search for a setup.cfg, tox.ini, or .pep8 file and, if one is found, passes it to flake8. The linter-flake8 package settings will override any settings in your config.

This fixes #8 