### PR TITLE
Update package.json to be APIv1.0-compliant

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "./lib/init",
   "version": "1.4.0",
   "description": "Atom linter plugin for Python, using flake8",
-  "activationEvents": [],
+  "activationCommands": [],
   "repository": {
     "type": "git",
     "url": "https://github.com/AtomLinter/linter-flake8"


### PR DESCRIPTION
activationEvents was deprecated in favor of activationCommands. The field is empty — probably because this package is invoked by the linter, and not by the user, and so a straight s/activationCommands/activationEvents seems to work fine, and eliminates the warning in DeprecationCop.

Closes #29.