### PR TITLE
Fix package.json to use activationCommands instead of activationEvents

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "./lib/init",
   "version": "1.4.0",
   "description": "Atom linter plugin for Python, using flake8",
-  "activationEvents": [],
+  "activationCommands": {},
   "repository": {
     "type": "git",
     "url": "https://github.com/AtomLinter/linter-flake8"


### PR DESCRIPTION
This fixes a Deprecation Cop warning notifying that the activationEvents key is deprecated in favor of activationCommands.

The specific warning is "Use activationCommands instead of activationEvents in your package.json".