### PR TITLE
Add hacking module support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ or:
    pip install flake8-pep257
    ```
 
+To support [OpenStack Style Guidelines](http://google-styleguide.googlecode.com/svn/trunk/pyguide.html), you will also need to install [hacking](https://github.com/openstack-dev/hacking) module:
+  ```
+  pip install hacking
+  ```
+
 Install plugin by typing:
    ```
    $ apm install linter-flake8

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ in a terminal:
    pip install flake8
    ```
 
+Install plugin by typing:
+   ```
+   $ apm install linter-flake8
+   ```
+
+##### Bult-in docstrings check (Optional)
 To include built-in docstrings (pep257) support you will also need to install:
    ```
    pip install flake8-docstrings
@@ -28,15 +34,11 @@ or:
    pip install flake8-pep257
    ```
 
+##### OpenStack Style Guidelines check (Optional)
 To support [OpenStack Style Guidelines](http://google-styleguide.googlecode.com/svn/trunk/pyguide.html), you will also need to install [hacking](https://github.com/openstack-dev/hacking) module:
   ```
   pip install hacking
   ```
-
-Install plugin by typing:
-   ```
-   $ apm install linter-flake8
-   ```
 
 ### Settings
 You can configure linter-flake8 as nearly all [Atom](https://atom.io/) modules by editing plugin settings in *Atom->Preferences->Packages->linter-flake-8*.

--- a/lib/linter-flake8.coffee
+++ b/lib/linter-flake8.coffee
@@ -16,7 +16,7 @@ class LinterFlake8 extends Linter
   regex:
     '(.*?):(?<line>\\d+):(?<col>\\d+): ' +
     '(?<message>((?<error>E11|E9)|' +
-    '(?<warning>W|E|F4|F84|N*|C|D|Q)|F)\\d+ .*?)\r?\n'
+    '(?<warning>W|E|F4|F84|N*|C|D|Q|H)|F)\\d+ .*?)\r?\n'
 
   constructor: (editor)->
     super(editor)


### PR DESCRIPTION
`hacking` module is extended linter of flake8, which also checks codes to follow OpenStack Style Guidelines.
Warning outputs from this module begin with 'H'.

### Link
* [openstack-dev/hacking - GitHub](https://github.com/openstack-dev/hacking)
* [OpenStack Style Guidelines](http://docs.openstack.org/developer/hacking/)