### PR TITLE
Support for selecting configuration file

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -8,6 +8,18 @@ module.exports =
       default: 'flake8'
       description: 'You might need a different binary name for python2 ' +
                    '(e.g. flake8-python2)'
+    configFileNames:
+      type: 'array'
+      default: []
+      items:
+        type: 'string'
+      description: 'Use configuration for flake8 in this file (search is ' +
+                   'from CWD up until the file is found or the root is ' +
+                   'reached). If this is empty, or the file is not found, ' +
+                   'the configuration options from this settings panel will ' +
+                   'be used. Can be a comma-separated list, in which case ' +
+                   'filenames are searched left to right and the first one ' +
+                   'found is used.'
     maxLineLength:
       type: 'integer'
       default: 0

--- a/lib/linter-flake8.coffee
+++ b/lib/linter-flake8.coffee
@@ -3,6 +3,9 @@ linterPath = atom.packages.getLoadedPackage("linter").path
 Linter = require "#{linterPath}/lib/linter"
 {findFile} = require "#{linterPath}/lib/utils"
 
+arrayEqual = (a, b) ->
+  a.length is b.length and a.every (elem, i) -> elem is b[i]
+
 class LinterFlake8 extends Linter
   @syntax: ['source.python']
 
@@ -21,7 +24,9 @@ class LinterFlake8 extends Linter
   constructor: (editor)->
     super(editor)
 
-    @configFile = findFile @cwd, ['setup.cfg', 'tox.ini', '.pep8']
+    @conf_file_names = []
+    @configFile = ''
+    @updateConfigFile()
 
     @executableDirListener = atom.config.observe 'linter-flake8.executableDir', =>
       executableDir = atom.config.get 'linter-flake8.executableDir'
@@ -30,6 +35,9 @@ class LinterFlake8 extends Linter
         @executablePath = if executableDir.length > 0 then executableDir else null
 
     @binaryNameListener = atom.config.observe 'linter-flake8.binaryName', =>
+      @updateCommand()
+
+    @configFileNamesListener = atom.config.observe 'linter-flake8.configFileNames', =>
       @updateCommand()
 
     @maxLineLengthListener = atom.config.observe 'linter-flake8.maxLineLength', =>
@@ -56,6 +64,24 @@ class LinterFlake8 extends Linter
     @selectErrorsListener.dispose()
     @hangClosingListener.dispose()
 
+  updateConfigFile: ->
+    # get the config file value, if it is different to what is stored in this
+    # object (i.e. it has changed), parse the value and search for a matching
+    # file
+    n_conf_file_names = atom.config.get 'linter-flake8.configFileNames'
+    if not arrayEqual n_conf_file_names, @conf_file_names
+      console.log 'need update'
+      @conf_file_names = n_conf_file_names
+
+      # strip whitespace from each name and remove any empy strings
+      tmp_file_names = (i.replace /^\s+|\s+$/g, "" for i in @conf_file_names)
+      tmp_file_names = (i for i in tmp_file_names when i isnt '')
+      @configFile = ''
+      if tmp_file_names.length > 0
+        @configFile = findFile @cwd, tmp_file_names
+    else
+      console.log 'no udpate needed, equal.'
+
   updateCommand: ->
     binary_name = atom.config.get 'linter-flake8.binaryName'
     maxLineLength = atom.config.get 'linter-flake8.maxLineLength'
@@ -63,6 +89,7 @@ class LinterFlake8 extends Linter
     maxComplexity = atom.config.get 'linter-flake8.maxComplexity'
     selectErrors = atom.config.get 'linter-flake8.selectErrors'
     hangClosing = atom.config.get 'linter-flake8.hangClosing'
+    @updateConfigFile()
 
     cmd = [binary_name]
 
@@ -70,6 +97,10 @@ class LinterFlake8 extends Linter
       # skip plugins settings if config file is found
       cmd.push '--config', @configFile
     else
+      # give a dummy value for the config file if the user didn't want to
+      # use one, to stop Flake8 from looking for one in the CWD.
+      cmd.push '--config', ''
+
       if maxLineLength
         cmd.push '--max-line-length', maxLineLength
 
@@ -84,7 +115,6 @@ class LinterFlake8 extends Linter
 
       if hangClosing
         cmd.push '--hang-closing'
-
     @cmd = cmd
 
 module.exports = LinterFlake8


### PR DESCRIPTION
Added new text box to the settings so the user can specify the name(s) they want to use for local configuration files. Default is empty, which causes all local config files to be ignored and the settings in the configuration panel to be used. Fixes #41.