### PR TITLE
Enable linter on Python Django syntax

### DIFF
--- a/lib/linter-flake8.coffee
+++ b/lib/linter-flake8.coffee
@@ -4,7 +4,7 @@ Linter = require "#{linterPath}/lib/linter"
 {findFile} = require "#{linterPath}/lib/utils"
 
 class LinterFlake8 extends Linter
-  @syntax: ['source.python']
+  @syntax: ['source.python', 'source.python.django']
 
   executablePath: null
 


### PR DESCRIPTION
If `atom-language-django` is installed then python source files in a Django project use `Python Django` syntax. On that syntax the linter don't want to run. I need to switch to default `Python` syntax in order to have linter working.