### PR TITLE
Grab I*** warning messages

### DIFF
--- a/lib/linter-flake8.coffee
+++ b/lib/linter-flake8.coffee
@@ -19,7 +19,7 @@ class LinterFlake8 extends Linter
   regex:
     '(.*?):(?<line>\\d+):(?<col>\\d+): ' +
     '(?<message>((?<error>E11|E9)|' +
-    '(?<warning>W|E|F4|F84|N*|C|D|Q|H)|F)\\d+ .*?)\r?\n'
+    '(?<warning>W|E|F4|F84|N*|C|D|Q|H|I)|F)\\d+ .*?)\r?\n'
 
   constructor: (editor)->
     super(editor)


### PR DESCRIPTION
The [flake8-import-order](https://github.com/public/flake8-import-order) plugin provides a nifty way to nicely sort all imports according to two styles (cryptography or google). Why not add this to the linter-flake8 for all?