### PR TITLE
Compromise for passing a config file to flake8

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -3,20 +3,11 @@ module.exports =
     executablePath:
       type: 'string'
       default: 'flake8'
-      description: 'You might need a different binary name for python2 ' +
-        '(e.g. flake8-python2)'
-    configFileNames:
-      type: 'array'
-      default: []
-      items:
-        type: 'string'
-      description: 'Use configuration for flake8 in this file (search is ' +
-        'from CWD up until the file is found or the root is ' +
-        'reached). If this is empty, or the file is not found, ' +
-        'the configuration options from this settings panel will ' +
-        'be used. Can be a comma-separated list, in which case ' +
-        'filenames are searched left to right and the first one ' +
-        'found is used.'
+      description: 'Full path to binary (e.g. /usr/local/bin/flake8)'
+    projectConfigFile:
+      type: 'string'
+      default: ''
+      description: 'flake config file relative path from project (e.g. tox.ini or .flake8rc)'
     maxLineLength:
       type: 'integer'
       default: 0
@@ -40,6 +31,7 @@ module.exports =
 
   provideLinter: ->
     helpers = require('atom-linter')
+    path = require('path')
 
     provider =
       grammarScopes: ['source.python', 'source.python.django']
@@ -60,6 +52,8 @@ module.exports =
           parameters.push('--hang-closing')
         if (selectErrors = atom.config.get('linter-flake8.selectErrors')).length
           parameters.push('--select', selectErrors.join(','))
+        if (projectConfigFile = atom.config.get('linter-flake8.projectConfigFile'))
+          parameters.push('--config', path.join(atom.project.getPaths()[0], projectConfigFile))
         parameters.push('-')
 
         return helpers.exec(atom.config.get('linter-flake8.executablePath'), parameters, stdin: fileText).then (result) ->


### PR DESCRIPTION
Issue #66 is something that I ran into, too, and when I looked at
the code configFileName wasn't even implemented.

I'm also not a flake8 expert, but it looks like flake8 has some
default locations that it looks in for config files, but what
I really want is the ability to add a project specific flake8
config file.

I removed the unused config file config parameter and added
a projectConfigFile setting that won't conflict with any previous
config settings that might exist (they'll remain no-ops).

There isn't a load of error checking in the code so I didn't try
too hard to bulletproof this, and it works perfectly for my needs.

If anyone else wants it, feel free to accept, modify, whatever.