### PR TITLE
Auto-install linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,35 @@
 linter-flake8
 =============
 
-linter-flake8 is a [flake8](https://pypi.python.org/pypi/flake8 provider for [Linter](https://github.com/AtomLinter/Linter).
+linter-flake8 is a [flake8](https://pypi.python.org/pypi/flake8) provider for [Linter](https://github.com/AtomLinter/Linter).
 
 ![img](https://cloud.githubusercontent.com/assets/4278113/8768482/52f975c6-2e3f-11e5-87e4-27c8359fd36c.gif)
 
-### Requirements
-Linter package must be installed in order to use this plugin. If it's not
-installed, please follow the instructions [here](https://github.com/AtomLinter/Linter).
-
 ### Installation
-To use a plugin, you must ensure that `flake8` is installed on your
-system.
-
-Install [flake8](https://pypi.python.org/pypi/flake8) by typing the following
+To use this plugin `flake8` will need to be installed on your
+system. If it is not already installed, you can install [flake8](https://pypi.python.org/pypi/flake8) by typing the following
 in a terminal:
-   ```
-   pip install flake8
-   ```
+```ShellSession
+pip install flake8
+```
 
-Install plugin by typing:
-   ```
-   $ apm install linter-flake8
-   ```
+You can then install this package from with Atom or by typing:
+```ShellSession
+$ apm install linter-flake8
+```
+
+_Note: If the `linter` package is not currently installed, it will be installed
+for you._
 
 ##### Bult-in docstrings check (Optional)
 To include built-in docstrings (pep257) support you will also need to install:
-   ```
-   pip install flake8-docstrings
-   ```
+```ShellSession
+pip install flake8-docstrings
+```
 or:
-   ```
-   pip install flake8-pep257
-   ```
+```ShellSession
+pip install flake8-pep257
+```
 
 ##### OpenStack Style Guidelines check (Optional)
 To support [OpenStack Style Guidelines](http://google-styleguide.googlecode.com/svn/trunk/pyguide.html), you will also need to install [hacking](https://github.com/openstack-dev/hacking) module:
@@ -50,7 +47,7 @@ in *Atom* menu).
 
 In configuration you can specify executable directory if node hasn't it in **$PATH**. Example:
 
-```
+```cson
 'linter-flake8':
   'executableDir': '/usr/local/bin/'
 ```

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -29,6 +29,9 @@ module.exports =
       items:
         type: 'string'
 
+  activate: ->
+    require('atom-package-deps').install('linter-flake8')
+
   provideLinter: ->
     helpers = require('atom-linter')
     path = require('path')

--- a/package.json
+++ b/package.json
@@ -9,8 +9,12 @@
   },
   "license": "MIT",
   "dependencies": {
-    "atom-linter": "^2.0.0"
+    "atom-linter": "^3.0.0",
+    "atom-package-deps": "^2.0.5"
   },
+  "package-deps": [
+    "linter"
+  ],
   "providedServices": {
     "linter": {
       "versions": {


### PR DESCRIPTION
Use `atom-package-deps` to automatically install the `linter` package if it isn't already installed.

Closes #76.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-flake8/79)
<!-- Reviewable:end -->
