### PR TITLE
Specify current working directory

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -61,7 +61,8 @@ module.exports =
         parameters.push('-')
 
         execPath = atom.config.get('linter-flake8.executablePath')
-        return helpers.exec(execPath, parameters, stdin: fileText).then (result) ->
+        cwd = path.dirname(textEditor.getPath())
+        return helpers.exec(execPath, parameters, {stdin: fileText, cwd: cwd}).then (result) ->
           toReturn = []
           regex = /(\d+):(\d+):\s(([A-Z])\d{2,3})\s+(.*)/g
 


### PR DESCRIPTION
Specify the current working directory, allowing custom wrapper scripts to work better.

Reimplementation of #77.