### PR TITLE
Check the return of lineTextForScreenRow

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -96,6 +96,8 @@ extractRange = ({code, message, lineNumber, colNumber, textEditor}) ->
     when 'W291'
       # W291 - trailing whitespace
       screenLine = textEditor.lineTextForScreenRow(lineNumber)
+      if screenLine is undefined
+        break
       return [[lineNumber, colNumber - 1], [lineNumber, screenLine.length]]
   return [[lineNumber, colNumber - 1], [lineNumber, colNumber]]
 


### PR DESCRIPTION
This function can (and will) return undefined if lines are folded in the buffer as it uses `tokenizedLineForScreenRow()` internally.

Fixes #108.