### PR TITLE
Normalize executable path.

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -178,7 +178,8 @@ module.exports =
           parameters.push('--config', path.join(atom.project.getPaths()[0], projectConfigFile))
         parameters.push('-')
 
-        execPath = atom.config.get('linter-flake8.executablePath')
+        fs = require('fs-plus')
+        execPath = fs.normalize(atom.config.get('linter-flake8.executablePath'))
         pep8warn = atom.config.get('linter-flake8.pep8ErrorsToWarnings')
         flakeerr = atom.config.get('linter-flake8.flakeErrors')
         cwd = path.dirname(textEditor.getPath())

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "atom-linter": "^4.3.4",
-    "atom-package-deps": "^4.0.1"
+    "atom-package-deps": "^4.0.1",
+    "fs-plus": "^2.8.1"
   },
   "devDependencies": {
     "coffeelint": "^1.14.2",


### PR DESCRIPTION
Allows *nix users to provide paths such as `~/bin/flake8`, which should correctly normalize to `/path/to/your/user/bin/flake8`.