### PR TITLE
$PROJECT_NAME substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ editing the settings in _Atom -> Preferences -> Packages -> linter-flake8_.
 
 ![image](https://cloud.githubusercontent.com/assets/427137/10375451/758567d2-6dad-11e5-9b5e-3e820f4c3d57.png)
 
-Or if you prefere you can use Atom _config.cson_ file _~/.atom/config.cson_
+Or if you prefer you can use Atom _config.cson_ file _~/.atom/config.cson_
 (click _Open Your Config_ in _Atom_ menu).
 
 If you installed `flake8` in a location not in your `$PATH`, the Settings panel
@@ -78,8 +78,12 @@ will let you specify where it lives. For example:
 
 ```cson
 'linter-flake8':
-  'executableDir': '/usr/local/bin/'
+  'executablePath': '/usr/bin/flake8'
 ```
+
+The `executablePath` setting may use `$PROJECT` and `$PROJECT_NAME` for the path or name of the current project, respectively.
+
+
 
 ### Project configuration files
 

--- a/spec/linter-flake8-spec.js
+++ b/spec/linter-flake8-spec.js
@@ -152,6 +152,19 @@ describe('The flake8 provider for Linter', () => {
       });
     });
 
+    it('finds executable using project name', () => {
+      waitsForPromise(() => {
+        atom.config.set('linter-flake8.executablePath',
+          path.join('$PROJECT_NAME', 'flake8')
+        );
+        return lint(editor).then(() => {
+          expect(execSpy.mostRecentCall.args[0]).toEqual(
+            path.join('fixtures', 'flake8')
+          );
+        });
+      });
+    });
+
     it('normalizes executable path', () => {
       waitsForPromise(() => {
         atom.config.set('linter-flake8.executablePath',


### PR DESCRIPTION
**Changes:**
- Add support for substituting $PROJECT_NAME instead of the full project path
- flake8 executable is erroring on lint errors which causes atom to throw the following error. Log error to console instead.

```
Error: 1
    at exports.exec.parameters.exit (/Users/theisensanders/github/linter-flake8/node_modules/atom-linter/lib/helpers.js:47:27)
    at module.exports.BufferedProcess.handleEvents.triggerExitCallback (/Applications/Atom.app/Contents/Resources/app.asar/src/buffered-process.js:213:47)
    at /Applications/Atom.app/Contents/Resources/app.asar/src/buffered-process.js:220:18
    at Socket.<anonymous> (/Applications/Atom.app/Contents/Resources/app.asar/src/buffered-process.js:98:18)
    at emitOne (events.js:82:20)
    at Socket.emit (events.js:169:7)
    at Pipe._onclose (net.js:469:12)
```

Addresses comment https://github.com/AtomLinter/linter-flake8/pull/143#issuecomment-182315200 by @k4nar