### PR TITLE
Force the format to default

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -199,7 +199,7 @@ module.exports =
       lint: (textEditor) =>
         filePath = textEditor.getPath()
         fileText = textEditor.getText()
-        parameters = []
+        parameters = ['--format=default']
 
         if maxLineLength = atom.config.get('linter-flake8.maxLineLength')
           parameters.push('--max-line-length', maxLineLength)


### PR DESCRIPTION
Override any format specified in the configuration file so the parsing of the output isn't broken.


Fixes https://github.com/AtomLinter/linter-flake8/issues/172#issuecomment-230430165.