### PR TITLE
fix flake8 config param

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -207,7 +207,7 @@ module.exports =
           (projectPath = atom.project.relativizePath(filePath)[0]) and
           (configFilePath = helpers.findCached(projectPath, projectConfigFile.split(/[ ,]+/)))
         )
-          parameters.push('--config', path.join(projectPath, configFilePath))
+          parameters.push('--config', configFilePath)
         else
           if maxLineLength = atom.config.get('linter-flake8.maxLineLength')
             parameters.push('--max-line-length', maxLineLength)


### PR DESCRIPTION
`configFilePath` is already a absolute path, so it should not be joined with `projectPath`.

Currently it find's `tox.ini` in `/Users/user/Development/project/` and runs flake8 with
'--config /Users/user/Development/project/Users/user/Development/project/tox.ini'