### PR TITLE
Workaround a bug with E999 reporting

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -33,6 +33,15 @@ const extractRange = ({ code, message, lineNumber, colNumber, textEditor }) => {
     case 'H501':
       result = rangeHelpers.noLocalsString(textEditor, line);
       break;
+    case 'E999':
+      // E999 - SyntaxError: unexpected EOF while parsing
+
+      // Workaround for https://gitlab.com/pycqa/flake8/issues/237
+      result = {
+        line,
+        col: colNumber - 2,
+      };
+      break;
     default:
       result = {
         line,


### PR DESCRIPTION
Currently the E999 error seems to always report 2 colums farther than it should, force it to be 2 less to fit within the valid range.

See https://gitlab.com/pycqa/flake8/issues/237 for more details.