### PR TITLE
Fix E901 error display

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -42,6 +42,12 @@ const extractRange = ({ code, message, lineNumber, colNumber, textEditor }) => {
         col: colNumber - 2,
       };
       break;
+    case 'E901':
+      result = {
+        line,
+        col: 0,
+      };
+      break;
     default:
       result = {
         line,


### PR DESCRIPTION
This seems to fix https://github.com/AtomLinter/linter-flake8/issues/270.

From briefly reading the code I think this part of the code determines the range of text under which the squiggle line appears. My change set it to 0 which will mark the entire line as the error, which I think is fine for the purpose of suppressing the errors.