### PR TITLE
Improve Atom startup time

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "engines": {
     "atom": ">=1.9.0 <2.0.0"
   },
+  "activationHooks": ["language-python:grammar-used"],
   "configSchema": {
     "executablePath": {
       "type": "string",

--- a/spec/linter-flake8-spec.js
+++ b/spec/linter-flake8-spec.js
@@ -12,14 +12,22 @@ describe('The flake8 provider for Linter', () => {
   const lint = require('../lib/main.js').provideLinter().lint;
 
   beforeEach(() => {
+    // This whole beforeEach function is inspired by:
+    // https://github.com/AtomLinter/linter-jscs/pull/295/files
+    //
+    // See also:
+    // https://discuss.atom.io/t/activationhooks-break-unit-tests/36028/8
+    const activationPromise =
+      atom.packages.activatePackage('linter-flake8');
+
     waitsForPromise(() =>
-      Promise.all([
-        atom.packages.activatePackage('linter-flake8'),
-        atom.packages.activatePackage('language-python'),
-      ]).then(() =>
-        atom.workspace.open(goodPath)
-      )
-    );
+      atom.packages.activatePackage('language-python'));
+
+    waitsForPromise(() =>
+      atom.workspace.open(goodPath));
+
+    atom.packages.triggerDeferredActivationHooks();
+    waitsForPromise(() => activationPromise);
   });
 
   it('should be in the packages list', () =>

--- a/spec/linter-flake8-spec.js
+++ b/spec/linter-flake8-spec.js
@@ -12,19 +12,16 @@ describe('The flake8 provider for Linter', () => {
   const lint = require('../lib/main.js').provideLinter().lint;
 
   beforeEach(() => {
-    // This whole beforeEach function is inspired by:
-    // https://github.com/AtomLinter/linter-jscs/pull/295/files
-    //
-    // See also:
-    // https://discuss.atom.io/t/activationhooks-break-unit-tests/36028/8
+    // Info about this beforeEach() implementation:
+    // https://github.com/AtomLinter/Meta/issues/15
     const activationPromise =
       atom.packages.activatePackage('linter-flake8');
 
     waitsForPromise(() =>
-      atom.packages.activatePackage('language-python'));
+      atom.packages.activatePackage('language-python').then(() =>
+        waitsForPromise(() =>
+          atom.workspace.open(goodPath))));
 
-    waitsForPromise(() =>
-      atom.workspace.open(goodPath));
 
     atom.packages.triggerDeferredActivationHooks();
     waitsForPromise(() => activationPromise);

--- a/spec/linter-flake8-spec.js
+++ b/spec/linter-flake8-spec.js
@@ -19,9 +19,7 @@ describe('The flake8 provider for Linter', () => {
 
     waitsForPromise(() =>
       atom.packages.activatePackage('language-python').then(() =>
-        waitsForPromise(() =>
-          atom.workspace.open(goodPath))));
-
+        atom.workspace.open(goodPath)));
 
     atom.packages.triggerDeferredActivationHooks();
     waitsForPromise(() => activationPromise);


### PR DESCRIPTION
Before this change, activation was done on Atom startup, whether or not
you actually had any Python files open.

With this change in place, we postpone activation until the Atom Python
grammar's first use.

This improves startup time of my Atom by about 100ms, fixing one of the
top startup time offenders according to TimeCop.

For some frame of reference, I have 90 packages installed, and Timecop
lists all packages with startup times above 5ms.