### PR TITLE
Handle errors more gracefully

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -12,6 +12,7 @@ const parseRegex = /(\d+):(\d+):\s(([A-Z])\d{2,3})\s+(.*)/g;
 
 const extractRange = ({ code, message, lineNumber, colNumber, textEditor }) => {
   let result;
+  // Make the given line 0-indexed
   const line = lineNumber - 1;
   switch (code) {
     case 'C901':
@@ -33,16 +34,8 @@ const extractRange = ({ code, message, lineNumber, colNumber, textEditor }) => {
     case 'H501':
       result = rangeHelpers.noLocalsString(textEditor, line);
       break;
-    case 'E999':
-      // E999 - SyntaxError: unexpected EOF while parsing
-
-      // Workaround for https://gitlab.com/pycqa/flake8/issues/237
-      result = {
-        line,
-        col: colNumber - 2,
-      };
-      break;
     default:
+      // By default just correct the column to be 0-indexed
       result = {
         line,
         col: colNumber - 1,

--- a/lib/main.js
+++ b/lib/main.js
@@ -94,6 +94,45 @@ const getVersionString = async (versionPath) => {
   return getVersionString.cache.get(versionPath);
 };
 
+const generateInvalidPointTrace = async (execPath, match, filePath, textEditor, point) => {
+  const flake8Version = await getVersionString(execPath);
+  const issueURL = 'https://github.com/AtomLinter/linter-flake8/issues/new';
+  const title = encodeURIComponent(`Flake8 rule '${match[3]}' reported an invalid point`);
+  const body = encodeURIComponent([
+    `Flake8 reported an invalid point for the rule \`${match[3]}\`, ` +
+    `with the messge \`${match[5]}\`.`,
+    '', '',
+    '<!-- If at all possible, please include code that shows this issue! -->',
+    '', '',
+    'Debug information:',
+    `Atom version: ${atom.getVersion()}`,
+    `Flake8 version: \`${flake8Version}\``,
+  ].join('\n'));
+  const newIssueURL = `${issueURL}?title=${title}&body=${body}`;
+  return {
+    type: 'Error',
+    severity: 'error',
+    html: 'ERROR: Flake8 provided an invalid point! See the trace for details. ' +
+      `<a href="${newIssueURL}">Report this!</a>`,
+    filePath,
+    range: helpers.rangeFromLineNumber(textEditor, 0),
+    trace: [
+      {
+        type: 'Trace',
+        text: `Original message: ${match[3]} — ${match[5]}`,
+        filePath,
+        severity: 'info',
+      },
+      {
+        type: 'Trace',
+        text: `Requested point: ${point.line}:${point.col}`,
+        filePath,
+        severity: 'info',
+      },
+    ],
+  };
+};
+
 export default {
   activate() {
     require('atom-package-deps').install('linter-flake8');
@@ -237,43 +276,9 @@ export default {
               filePath,
               range,
             });
-          } catch (e) {
-            const flake8Version = await getVersionString(execPath);
-            const issueURL = 'https://github.com/AtomLinter/linter-flake8/issues/new';
-            const title = encodeURIComponent(`Flake8 rule '${match[3]}' reported an invalid point`);
-            const body = encodeURIComponent([
-              `Flake8 reported an invalid point for the rule \`${match[3]}\`, ` +
-              `with the messge \`${match[5]}\`.`,
-              '', '',
-              '<!-- If at all possible, please include code that shows this issue! -->',
-              '', '',
-              'Debug information:',
-              `Atom version: ${atom.getVersion()}`,
-              `Flake8 version: \`${flake8Version}\``,
-            ].join('\n'));
-            const newIssueURL = `${issueURL}?title=${title}&body=${body}`;
-            messages.push({
-              type: 'Error',
-              severity: 'error',
-              html: 'ERROR: Flake8 provided an invalid point! See the trace for details. ' +
-                `<a href="${newIssueURL}">Report this!</a>`,
-              filePath,
-              range: helpers.rangeFromLineNumber(textEditor, 0),
-              trace: [
-                {
-                  type: 'Trace',
-                  text: `Original message: ${match[3]} — ${match[5]}`,
-                  filePath,
-                  severity: 'info',
-                },
-                {
-                  type: 'Trace',
-                  text: `Requested point: ${e.line}:${e.col}`,
-                  filePath,
-                  severity: 'info',
-                },
-              ],
-            });
+          } catch (point) {
+            messages.push(await generateInvalidPointTrace(
+              execPath, match, filePath, textEditor, point));
           }
 
           match = parseRegex.exec(result.stdout);

--- a/lib/main.js
+++ b/lib/main.js
@@ -61,16 +61,9 @@ const extractRange = ({ code, message, lineNumber, colNumber, textEditor }) => {
   try {
     range = helpers.rangeFromLineNumber(textEditor, result.line, result.col);
   } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error(
-      'linter-flake8:: Invalid point encountered in the attached message',
-      {
-        code,
-        message,
-        requestedPoint: result,
-      }
-    );
-    throw Error('linter-flake8:: Invalid point encountered! See console for details.');
+    // rangeFromLineNumber encountered a problem, throw the result and report
+    // to the user.
+    throw result;
   }
 
   return range;
@@ -88,6 +81,17 @@ const applySubstitutions = (givenExecPath, projDir) => {
     }
   }
   return execPath;
+};
+
+const getVersionString = async (versionPath) => {
+  if (!Object.hasOwnProperty.call(getVersionString, 'cache')) {
+    getVersionString.cache = new Map();
+  }
+  if (!getVersionString.cache.has(versionPath)) {
+    getVersionString.cache.set(versionPath,
+      await helpers.exec(versionPath, ['--version']));
+  }
+  return getVersionString.cache.get(versionPath);
 };
 
 export default {
@@ -218,20 +222,59 @@ export default {
           const col = Number.parseInt(match[2], 10) || 0;
           const isErr = (match[4] === 'E' && !this.pycodestyleErrorsToWarnings)
             || (match[4] === 'F' && this.flakeErrors);
-          const range = extractRange({
-            code: match[3],
-            message: match[5],
-            lineNumber: line,
-            colNumber: col,
-            textEditor,
-          });
 
-          messages.push({
-            type: isErr ? 'Error' : 'Warning',
-            text: `${match[3]} — ${match[5]}`,
-            filePath,
-            range,
-          });
+          try {
+            const range = extractRange({
+              code: match[3],
+              message: match[5],
+              lineNumber: line,
+              colNumber: col,
+              textEditor,
+            });
+            messages.push({
+              type: isErr ? 'Error' : 'Warning',
+              text: `${match[3]} — ${match[5]}`,
+              filePath,
+              range,
+            });
+          } catch (e) {
+            const flake8Version = await getVersionString(execPath);
+            const issueURL = 'https://github.com/AtomLinter/linter-flake8/issues/new';
+            const title = encodeURIComponent(`Flake8 rule '${match[3]}' reported an invalid point`);
+            const body = encodeURIComponent([
+              `Flake8 reported an invalid point for the rule \`${match[3]}\`, ` +
+              `with the messge \`${match[5]}\`.`,
+              '', '',
+              '<!-- If at all possible, please include code that shows this issue! -->',
+              '', '',
+              'Debug information:',
+              `Atom version: ${atom.getVersion()}`,
+              `Flake8 version: \`${flake8Version}\``,
+            ].join('\n'));
+            const newIssueURL = `${issueURL}?title=${title}&body=${body}`;
+            messages.push({
+              type: 'Error',
+              severity: 'error',
+              html: 'ERROR: Flake8 provided an invalid point! See the trace for details. ' +
+                `<a href="${newIssueURL}">Report this!</a>`,
+              filePath,
+              range: helpers.rangeFromLineNumber(textEditor, 0),
+              trace: [
+                {
+                  type: 'Trace',
+                  text: `Original message: ${match[3]} — ${match[5]}`,
+                  filePath,
+                  severity: 'info',
+                },
+                {
+                  type: 'Trace',
+                  text: `Requested point: ${e.line}:${e.col}`,
+                  filePath,
+                  severity: 'info',
+                },
+              ],
+            });
+          }
 
           match = parseRegex.exec(result.stdout);
         }

--- a/lib/main.js
+++ b/lib/main.js
@@ -125,7 +125,7 @@ const generateInvalidPointTrace = async (execPath, match, filePath, textEditor, 
       },
       {
         type: 'Trace',
-        text: `Requested point: ${point.line}:${point.col}`,
+        text: `Requested point: ${point.line + 1}:${point.col + 1}`,
         filePath,
         severity: 'info',
       },


### PR DESCRIPTION
Previously we were throwing almost a raw error message to the user. Trap this and generate a "linter message" stating that an invalid point was encountered. Details of the original message are included as traces on the message. In addition, a link is given sending the user to the new issue page with some debugging information, and prompting for code sample.

For example (using the `linter-ui-default` package):

In the panel:
![image](https://cloud.githubusercontent.com/assets/427137/20445895/e6f0a4d0-ad8b-11e6-9471-e5d5e7fea289.png)

Tooltips:
![image](https://cloud.githubusercontent.com/assets/427137/20447074/bd8ab242-ad91-11e6-9433-45938d0f08e1.png)

And the issue generated when "Report this!" is clicked:
![image](https://cloud.githubusercontent.com/assets/427137/20445937/0e08246c-ad8c-11e6-887c-e00fda8b7857.png)


Marking this as closing the following issues, since they are all related to invalid points but don't have enough information to act on them. This method should both make it less intrusive to the user, and provide more information where possible.

Closes #271.
Closes #266.
Closes #273. (Although this also mentions another error, I'm not sure if that is actually due to `linter-flake8` as the trace is ambiguous.)

I'm leaving #270 open for the moment as that seems to be where people have converged on these issues.