### PR TITLE
Activate on more grammars

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
   "engines": {
     "atom": ">=1.9.0 <2.0.0"
   },
-  "activationHooks": ["language-python:grammar-used"],
+  "activationHooks": [
+    "language-python:grammar-used",
+    "MagicPython:grammar-used",
+    "atom-django:grammar-used"
+  ],
   "configSchema": {
     "executablePath": {
       "type": "string",


### PR DESCRIPTION
Fixes #280 by using the same activationHooks as here:
https://github.com/autocomplete-python/autocomplete-python/blob/master/package.json