### PR TITLE
Update to eslint-config-airbnb-base v11.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "devDependencies": {
     "eslint": "^3.12.0",
-    "eslint-config-airbnb-base": "^11.0.0",
+    "eslint-config-airbnb-base": "^11.1.1",
     "eslint-plugin-import": "^2.2.0"
   },
   "package-deps": [

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "fs-plus": "^3.0.0"
   },
   "devDependencies": {
-    "eslint": "^3.12.0",
+    "eslint": "^3.16.1",
     "eslint-config-airbnb-base": "^11.1.1",
     "eslint-plugin-import": "^2.2.0"
   },


### PR DESCRIPTION
As this version bumps the minimum ESLint version it needs to be updated in the dependency list.