### PR TITLE
Update default line-length value

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -159,7 +159,7 @@ export default {
           if (this.ignoreErrorCodes.length) {
             parameters.push('--ignore', this.ignoreErrorCodes.join(','));
           }
-          if (this.maxComplexity) {
+          if (this.maxComplexity !== 79) {
             parameters.push('--max-complexity', this.maxComplexity);
           }
           if (this.hangClosing) {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     },
     "maxLineLength": {
       "type": "integer",
-      "default": 0
+      "default": 79
     },
     "ignoreErrorCodes": {
       "type": "array",


### PR DESCRIPTION
Change the default maxLineLength value to match the default that `flake8` uses whenever it isn't specified in the first place. The previous default of '0' implied that it did nothing, when in fact it just didn't modify the default that `flake8` uses.

Fixes #379.