### PR TITLE
Uniquely spawn lint runs

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -77,11 +77,13 @@ export default {
   activate() {
     require('atom-package-deps').install('linter-flake8');
 
+    // FIXME: Remove after a few versions
+    if (typeof atom.config.get('linter-flake8.disableTimeout') !== 'undefined') {
+      atom.config.unset('linter-flake8.disableTimeout');
+    }
+
     this.subscriptions = new CompositeDisposable();
     this.subscriptions.add(
-      atom.config.observe('linter-flake8.disableTimeout', (value) => {
-        this.disableTimeout = value;
-      }),
       atom.config.observe('linter-flake8.projectConfigFile', (value) => {
         this.projectConfigFile = value;
       }),
@@ -161,16 +163,21 @@ export default {
         parameters.push('-');
 
         const execPath = fs.normalize(applySubstitutions(this.executablePath, baseDir));
+        const forceTimeout = 1000 * 60 * 5; // (ms * s * m) = Five minutes
         const options = {
           stdin: fileText,
           cwd: path.dirname(textEditor.getPath()),
           stream: 'both',
+          timeout: forceTimeout,
+          uniqueKey: `linter-flake8:${filePath}`,
         };
-        if (this.disableTimeout) {
-          options.timeout = Infinity;
-        }
 
         const result = await helpers.exec(execPath, parameters, options);
+
+        if (result === null) {
+          // Process was killed by a future invocation
+          return null;
+        }
 
         if (textEditor.getText() !== fileText) {
           // Editor contents have changed, tell Linter not to update

--- a/package.json
+++ b/package.json
@@ -23,11 +23,6 @@
       "default": "flake8",
       "description": "Semicolon separated list of paths to a binary (e.g. /usr/local/bin/flake8). Use `$PROJECT` or `$PROJECT_NAME` substitutions for project specific paths e.g. `$PROJECT/.venv/bin/flake8;/usr/bin/flake8`"
     },
-    "disableTimeout": {
-      "type": "boolean",
-      "default": false,
-      "description": "Disable the 10 second execution timeout"
-    },
     "projectConfigFile": {
       "type": "array",
       "default": [],


### PR DESCRIPTION
For each file only allow a single instance of `flake8` to be running at a time, forcing a timeout of 5 minutes if not interrupted/exited before hand.

Fixes #383.