### PR TITLE
Defer package dependency check

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -75,12 +75,24 @@ const generateInvalidPointTrace = async (execPath, match, filePath, textEditor, 
 
 export default {
   activate() {
-    require('atom-package-deps').install('linter-flake8');
+    this.idleCallbacks = new Set();
 
-    // FIXME: Remove after a few versions
-    if (typeof atom.config.get('linter-flake8.disableTimeout') !== 'undefined') {
-      atom.config.unset('linter-flake8.disableTimeout');
-    }
+    let packageDepsID;
+    const linterFlake8Deps = () => {
+      this.idleCallbacks.delete(packageDepsID);
+
+      // Request checking / installation of package dependencies
+      if (!atom.inSpecMode()) {
+        require('atom-package-deps').install('linter-flake8');
+      }
+
+      // FIXME: Remove after a few versions
+      if (typeof atom.config.get('linter-flake8.disableTimeout') !== 'undefined') {
+        atom.config.unset('linter-flake8.disableTimeout');
+      }
+    };
+    packageDepsID = window.requestIdleCallback(linterFlake8Deps);
+    this.idleCallbacks.add(packageDepsID);
 
     this.subscriptions = new CompositeDisposable();
     this.subscriptions.add(
@@ -118,6 +130,8 @@ export default {
   },
 
   deactivate() {
+    this.idleCallbacks.forEach(callbackID => window.cancelIdleCallback(callbackID));
+    this.idleCallbacks.clear();
     this.subscriptions.dispose();
   },
 

--- a/package.json
+++ b/package.json
@@ -113,7 +113,8 @@
       "atom": true
     },
     "env": {
-      "node": true
+      "node": true,
+      "browser": true
     }
   },
   "providedServices": {


### PR DESCRIPTION
Defer checking for required package dependencies till Atom has some idle time as we don't need it immediately in activation of this package.

As this package alerady waits on an `activationHook`, this isn't as large of a benefit as other providers, but will still help the time of the first lint.