### PR TITLE
Report when flake8 crashes!

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -181,12 +181,27 @@ export default {
         const options = {
           stdin: fileText,
           cwd: path.dirname(textEditor.getPath()),
-          stream: 'both',
+          ignoreExitCode: true,
           timeout: forceTimeout,
           uniqueKey: `linter-flake8:${filePath}`,
         };
 
-        const result = await helpers.exec(execPath, parameters, options);
+        let result;
+        try {
+          result = await helpers.exec(execPath, parameters, options);
+        } catch (e) {
+          const pyTrace = e.message.split('\n');
+          const pyMostRecent = pyTrace[pyTrace.length - 1];
+          atom.notifications.addError('Flake8 crashed!', {
+            detail: 'linter-flake8:: Flake8 threw an error related to:\n' +
+              `${pyMostRecent}\n` +
+              "Please check Atom's Console for more details",
+          });
+          // eslint-disable-next-line no-console
+          console.error('linter-flake8:: Flake8 returned an error', e.message);
+          // Tell Linter to not update any current messages it may have
+          return null;
+        }
 
         if (result === null) {
           // Process was killed by a future invocation
@@ -198,13 +213,9 @@ export default {
           return null;
         }
 
-        if (result.stderr && result.stderr.length && atom.inDevMode()) {
-          // eslint-disable-next-line no-console
-          console.log(`flake8 stderr: ${result.stderr}`);
-        }
         const messages = [];
 
-        let match = parseRegex.exec(result.stdout);
+        let match = parseRegex.exec(result);
         while (match !== null) {
           // Note that these positions are being converted to 0-indexed
           const line = Number.parseInt(match[1], 10) - 1 || 0;
@@ -226,7 +237,7 @@ export default {
               execPath, match, filePath, textEditor, point));
           }
 
-          match = parseRegex.exec(result.stdout);
+          match = parseRegex.exec(result);
         }
         // Ensure that any invalid point messages have finished resolving
         return Promise.all(messages);


### PR DESCRIPTION
When flake8 crashes for some reason this was being transparently hidden from the user. Instead show the most recent call to the user, with the full Python stack trace being printed to the console.

Example:
![image](https://cloud.githubusercontent.com/assets/427137/25411156/e66e6658-29cf-11e7-8f39-5096b691cc04.png)

![image](https://cloud.githubusercontent.com/assets/427137/25411169/fdf33ce0-29cf-11e7-9da4-602a227e62c8.png)

(Thanks to the current bug breaking `flake8-docstrings` for this simple reproduction case!)

The current behavior of hiding the error was introduced in https://github.com/AtomLinter/linter-flake8/pull/167 and unfortunately I didn't think of what the full rammifications were there and blindly trusted the report of:

> flake8 executable is erroring on lint errors which causes atom to throw the following error.
>> Error: 1

Which in hindsight sounds ridiculous and was likely a result of a system configuration issue from that user (who has since deleted their account).