### PR TITLE
Add support to default config files

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     },
     "projectConfigFile": {
       "type": "array",
-      "default": [],
+      "default": ["tox.ini", ".flake8", "setup.cfg"],
       "description": "flake config file relative path from project (e.g. tox.ini or .flake8rc)",
       "items": {
         "type": "string"


### PR DESCRIPTION
This PR tries to load the `tox.ini` file for loading linting rules.

The order of precedence is:
- Tries to load `projectConfigFile` if set
- Tries to load `tox.ini` if it exists
- Loads default configurations

The idea behind this is that if a project already has a `tox.ini`
file, it should try to use unless overriden. This works similar
to when `flake8` is run in the command line.

Fixes #124.