### PR TITLE
Use Trusty image on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ git:
 
 sudo: false
 
+dist: trusty
+
 addons:
   apt:
     packages:


### PR DESCRIPTION
Travis-CI builds of Atom beta are now required to be on the Trusty image to install all necessary dependencies properly.