### PR TITLE
Added small calrification about Flake messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
       "default": false
     },
     "selectErrors": {
-      "description": "input \"E, W\" to include all errors/warnings",
+      "description": "input \"E, W, F\" to include all errors/warnings. F includes the Flake messages",
       "type": "array",
       "default": [],
       "items": {


### PR DESCRIPTION
Added a small clarification in the Select Errors description since not putting the F option explicitly will not show the Flake messages rendering the "Flake Messages to Linter Errors" option useless.