### PR TITLE
Guard against invalid TextEditor and empty paths

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -179,10 +179,20 @@ export default {
       scope: 'file',
       lintOnFly: true,
       lint: async (textEditor) => {
-        loadDeps();
+        if (!atom.workspace.isTextEditor(textEditor)) {
+          // Invalid TextEditor
+          return null;
+        }
 
         const filePath = textEditor.getPath();
+        if (!filePath) {
+          // Invalid path
+          return null;
+        }
         const fileText = textEditor.getText();
+
+        // Load dependencies if they aren't already
+        loadDeps();
 
         const parameters = ['--format=default'];
 


### PR DESCRIPTION
Occasionally `lint()` somehow gets called with invalid `TextEditor`s, or ones without a path. When these cases are hit simply return `null` instead of trying to process them.

Fixes #527.