### PR TITLE
Default to .flake8 config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "projectConfigFile": {
       "type": "array",
       "default": [
-        "tox.ini",
         ".flake8",
+        "tox.ini",
         "setup.cfg"
       ],
       "description": "flake config file relative path from project (e.g. tox.ini or .flake8rc)",


### PR DESCRIPTION
Prefer .flake8 rather than tox.ini since the former can only be used for Flake8 while the latter may be present but not contain Flake8 config.

Related to #554.