### PR TITLE
Let flake8 handle the default config files

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -153,6 +153,9 @@ export default {
       atom.config.observe('linter-flake8.flakeErrors', (value) => {
         this.flakeErrors = value;
       }),
+      atom.config.observe('linter-flake8.flake8.alwaysOverride', (value) => {
+        this.alwaysOverride = value;
+      }),
       atom.config.observe('linter-flake8.flake8.maxLineLength', (value) => {
         this.maxLineLength = value;
       }),
@@ -219,7 +222,9 @@ export default {
 
         if (configFilePath) {
           parameters.push('--config', configFilePath);
-        } else if (!await hasDefaultConfigFile(baseDir)) {
+        }
+
+        if (this.alwaysOverride || (!configFilePath && !await hasDefaultConfigFile(baseDir))) {
           if (this.maxLineLength) {
             parameters.push('--max-line-length', this.maxLineLength);
           }

--- a/lib/main.js
+++ b/lib/main.js
@@ -26,6 +26,11 @@ function loadDeps() {
 // Local variables
 const parseRegex = /(\d+):(\d+):\s(([A-Z])\d{2,3})\s+(.*)/g;
 const execPathVersions = new Map();
+const defaultConfigFiles = [
+  '.flake8',
+  'tox.ini',
+  'setup.cfg',
+];
 
 const applySubstitutions = (givenExecPath, projDir) => {
   let execPath = givenExecPath;
@@ -101,6 +106,11 @@ const getFlake8Version = async (execPath) => {
   return execPathVersions.get(execPath);
 };
 
+const hasDefaultConfigFile = async (baseDir) => {
+  const ConfigFilePath = !!await helpers.findCachedAsync(baseDir, defaultConfigFiles);
+  return !!ConfigFilePath;
+};
+
 export default {
   activate() {
     this.idleCallbacks = new Set();
@@ -125,8 +135,8 @@ export default {
 
     this.subscriptions = new CompositeDisposable();
     this.subscriptions.add(
-      atom.config.observe('linter-flake8.projectConfigFile', (value) => {
-        this.projectConfigFile = value;
+      atom.config.observe('linter-flake8.configFile', (value) => {
+        this.configFile = value;
       }),
       atom.config.observe('linter-flake8.maxLineLength', (value) => {
         this.maxLineLength = value;
@@ -190,8 +200,8 @@ export default {
 
         const projectPath = atom.project.relativizePath(filePath)[0];
         const baseDir = projectPath !== null ? projectPath : path.dirname(filePath);
-        const configFilePath = await helpers.findCachedAsync(baseDir, this.projectConfigFile);
         const execPath = fs.normalize(applySubstitutions(this.executablePath, baseDir));
+        const configFilePath = await helpers.findCachedAsync(baseDir, this.configFile);
 
         // get the version of Flake8
         const version = await getFlake8Version(execPath);
@@ -201,9 +211,9 @@ export default {
           parameters.push('--stdin-display-name', filePath);
         }
 
-        if (this.projectConfigFile && baseDir !== null && configFilePath !== null) {
+        if (configFilePath) {
           parameters.push('--config', configFilePath);
-        } else {
+        } else if (!await hasDefaultConfigFile(baseDir)) {
           if (this.maxLineLength) {
             parameters.push('--max-line-length', this.maxLineLength);
           }

--- a/lib/main.js
+++ b/lib/main.js
@@ -7,6 +7,7 @@ let fs;
 let path;
 let helpers;
 let semver;
+let migrateConfigOptions;
 
 function loadDeps() {
   if (!semver) {
@@ -115,6 +116,11 @@ export default {
   activate() {
     this.idleCallbacks = new Set();
 
+    if (!migrateConfigOptions) {
+      migrateConfigOptions = require('./migrate-config-options');
+    }
+    migrateConfigOptions();
+
     let packageDepsID;
     const linterFlake8Deps = () => {
       this.idleCallbacks.delete(packageDepsID);
@@ -138,21 +144,6 @@ export default {
       atom.config.observe('linter-flake8.configFile', (value) => {
         this.configFile = value;
       }),
-      atom.config.observe('linter-flake8.maxLineLength', (value) => {
-        this.maxLineLength = value;
-      }),
-      atom.config.observe('linter-flake8.ignoreErrorCodes', (value) => {
-        this.ignoreErrorCodes = value;
-      }),
-      atom.config.observe('linter-flake8.maxComplexity', (value) => {
-        this.maxComplexity = value;
-      }),
-      atom.config.observe('linter-flake8.selectErrors', (value) => {
-        this.selectErrors = value;
-      }),
-      atom.config.observe('linter-flake8.hangClosing', (value) => {
-        this.hangClosing = value;
-      }),
       atom.config.observe('linter-flake8.executablePath', (value) => {
         this.executablePath = value;
       }),
@@ -162,7 +153,22 @@ export default {
       atom.config.observe('linter-flake8.flakeErrors', (value) => {
         this.flakeErrors = value;
       }),
-      atom.config.observe('linter-flake8.builtins', (value) => {
+      atom.config.observe('linter-flake8.flake8.maxLineLength', (value) => {
+        this.maxLineLength = value;
+      }),
+      atom.config.observe('linter-flake8.flake8.ignoreErrorCodes', (value) => {
+        this.ignoreErrorCodes = value;
+      }),
+      atom.config.observe('linter-flake8.flake8.maxComplexity', (value) => {
+        this.maxComplexity = value;
+      }),
+      atom.config.observe('linter-flake8.flake8.selectErrorCodes', (value) => {
+        this.selectErrorCodes = value;
+      }),
+      atom.config.observe('linter-flake8.flake8.hangClosing', (value) => {
+        this.hangClosing = value;
+      }),
+      atom.config.observe('linter-flake8.flake8.builtins', (value) => {
         this.builtins = value;
       }),
     );
@@ -226,8 +232,8 @@ export default {
           if (this.hangClosing) {
             parameters.push('--hang-closing');
           }
-          if (this.selectErrors.length) {
-            parameters.push('--select', this.selectErrors.join(','));
+          if (this.selectErrorCodes.length) {
+            parameters.push('--select', this.selectErrorCodes.join(','));
           }
           if (this.builtins.length) {
             parameters.push('--builtins', this.builtins.join(','));

--- a/lib/migrate-config-options.js
+++ b/lib/migrate-config-options.js
@@ -1,0 +1,71 @@
+'use babel';
+
+/*
+ * These migrations can take one of two forms, a direct move or a general function.
+ *
+ * Direct move:
+ *   These objects have an array of `moves`, which
+ *   are objects containing an `old` setting name and a `new` setting name.
+ *   Any existing config found in the `old` name will be moved over to (and overwrite)
+ *   the `new` key.
+ *
+ * Functions:
+ *   These have a `migrate` function, which takes the
+ *   current linter-flake8 atom config as an argument, and can act on it however
+ *   it needs to.
+ */
+const activeMigrations = [
+  {
+    added: 'January, 2019',
+    description: 'Grouped setting overrides for flake8',
+    moves: [
+      {
+        old: 'maxLineLength',
+        new: 'flake8.maxLineLength',
+      }, {
+        old: 'ignoreErrorCodes',
+        new: 'flake8.ignoreErrorCodes',
+      }, {
+        old: 'maxComplexity',
+        new: 'flake8.maxComplexity',
+      }, {
+        old: 'hangClosing',
+        new: 'flake8.hangClosing',
+      }, {
+        old: 'selectErrors',
+        new: 'flake8.selectErrorCodes',
+      }, {
+        old: 'builtins',
+        new: 'flake8.builtins',
+      },
+    ],
+  },
+];
+
+/*
+ * This function can be called when linter-flake8 first activates in order to
+ * ensure that the user's settings are up-to-date with the current version of
+ * linter-flake8.  Ideally, we would call this only when upgrading to a new
+ * version.
+ */
+function migrateConfigOptions(migrations = activeMigrations) {
+  if (migrations.length) {
+    const linterConfig = atom.config.get('linter-flake8');
+    migrations.forEach((migration) => {
+      if (migration.moves && Array.isArray(migration.moves)) {
+        // Copy old settings over to the new ones, then unset the old setting keys
+        migration.moves.forEach((move) => {
+          const oldSetting = linterConfig[move.old];
+          if (oldSetting !== undefined) {
+            atom.config.set(`linter-flake8.${move.new}`, oldSetting);
+            atom.config.unset(`linter-flake8.${move.old}`);
+          }
+        });
+      } else if (typeof migration.migrate === 'function') {
+        migration.migrate(linterConfig);
+      }
+    });
+  }
+}
+
+module.exports = migrateConfigOptions;

--- a/package.json
+++ b/package.json
@@ -23,14 +23,10 @@
       "default": "flake8",
       "description": "Semicolon separated list of paths to a binary (e.g. /usr/local/bin/flake8). Use `$PROJECT` or `$PROJECT_NAME` substitutions for project specific paths e.g. `$PROJECT/.venv/bin/flake8;/usr/bin/flake8`"
     },
-    "projectConfigFile": {
+    "configFile": {
       "type": "array",
-      "default": [
-        "tox.ini",
-        ".flake8",
-        "setup.cfg"
-      ],
-      "description": "flake config file relative path from project (e.g. tox.ini or .flake8rc)",
+      "default": [],
+      "description": "Override flake8 default config files, relative path from project (e.g. tox.ini or .flake8)",
       "items": {
         "type": "string"
       }

--- a/package.json
+++ b/package.json
@@ -50,10 +50,17 @@
       "title": "Override flake8 settings",
       "order": 5,
       "properties": {
+        "alwaysOverride": {
+          "title": "Override settings from config file",
+          "description": "Override settings from project config file (i.e. `.flake8`, `tox.ini`, `setup.cfg`, or manually specified ones).",
+          "type": "boolean",
+          "default": false,
+          "order": 1
+        },
         "maxLineLength": {
           "type": "integer",
           "default": 79,
-          "order": 1
+          "order": 2
         },
         "ignoreErrorCodes": {
           "description": "Comma-separated list of errors and warnings to ignore (e.g. `E4,E51,W234`).",
@@ -62,7 +69,7 @@
           "items": {
             "type": "string"
           },
-          "order": 2
+          "order": 3
         },
         "selectErrorCodes": {
           "description": "Comma-separated list of errors and warnings to enable (e.g. `E4,E51,W234`).",
@@ -71,7 +78,7 @@
           "items": {
             "type": "string"
           },
-          "order": 3
+          "order": 4
         },
         "builtins": {
           "description": "Comma-separated list of additional built in variables.",
@@ -80,19 +87,19 @@
           "items": {
             "type": "string"
           },
-          "order": 4
+          "order": 5
         },
         "maxComplexity": {
           "description": "McCabe complexity threshold (`-1` to disable).",
           "type": "integer",
           "default": -1,
-          "order": 5
+          "order": 6
         },
         "hangClosing": {
           "description": "Hang closing bracket instead of matching indentation of opening bracket's line.",
           "type": "boolean",
           "default": false,
-          "order": 6
+          "order": 7
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -21,61 +21,80 @@
     "executablePath": {
       "type": "string",
       "default": "flake8",
-      "description": "Semicolon separated list of paths to a binary (e.g. /usr/local/bin/flake8). Use `$PROJECT` or `$PROJECT_NAME` substitutions for project specific paths e.g. `$PROJECT/.venv/bin/flake8;/usr/bin/flake8`"
+      "description": "Semicolon-separated list of paths to a binary (e.g. `/usr/local/bin/flake8`). Use `$PROJECT` or `$PROJECT_NAME` substitutions for project specific paths (e.g. `$PROJECT/.venv/bin/flake8;/usr/bin/flake8`).",
+      "order": 1
     },
     "configFile": {
       "type": "array",
       "default": [],
-      "description": "Override flake8 default config files, relative path from project (e.g. tox.ini or .flake8)",
-      "items": {
-        "type": "string"
-      }
-    },
-    "maxLineLength": {
-      "type": "integer",
-      "default": 79
-    },
-    "ignoreErrorCodes": {
-      "type": "array",
-      "default": [],
-      "items": {
-        "type": "string"
-      }
-    },
-    "maxComplexity": {
-      "description": "McCabe complexity threshold (`-1` to disable)",
-      "type": "integer",
-      "default": -1
-    },
-    "hangClosing": {
-      "type": "boolean",
-      "default": false
-    },
-    "selectErrors": {
-      "description": "input \"E, W\" to include all errors/warnings",
-      "type": "array",
-      "default": [],
-      "items": {
-        "type": "string"
-      }
-    },
-    "pycodestyleErrorsToWarnings": {
-      "description": "Convert pycodestyle \"E\" messages to linter warnings",
-      "type": "boolean",
-      "default": false
-    },
-    "flakeErrors": {
-      "description": "Convert Flake \"F\" messages to linter errors",
-      "type": "boolean",
-      "default": false
-    },
-    "builtins": {
-      "type": "array",
-      "default": [],
+      "description": "Comma-separated list of relative paths (from project) to flake8 config files. If any is found, it overrides flake8 built-in config file discovery.",
       "items": {
         "type": "string"
       },
-      "description": "Define additional built in variables, in a comma separated list."
+      "order": 2
+    },
+    "flakeErrors": {
+      "description": "Convert flake8 `F` messages to linter errors.",
+      "type": "boolean",
+      "default": false,
+      "order": 3
+    },
+    "pycodestyleErrorsToWarnings": {
+      "description": "Convert pycodestyle `E` messages to linter warnings.",
+      "type": "boolean",
+      "default": false,
+      "order": 4
+    },
+    "flake8": {
+      "type": "object",
+      "title": "Override flake8 settings",
+      "order": 5,
+      "properties": {
+        "maxLineLength": {
+          "type": "integer",
+          "default": 79,
+          "order": 1
+        },
+        "ignoreErrorCodes": {
+          "description": "Comma-separated list of errors and warnings to ignore (e.g. `E4,E51,W234`).",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "order": 2
+        },
+        "selectErrorCodes": {
+          "description": "Comma-separated list of errors and warnings to enable (e.g. `E4,E51,W234`).",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "order": 3
+        },
+        "builtins": {
+          "description": "Comma-separated list of additional built in variables.",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "order": 4
+        },
+        "maxComplexity": {
+          "description": "McCabe complexity threshold (`-1` to disable).",
+          "type": "integer",
+          "default": -1,
+          "order": 5
+        },
+        "hangClosing": {
+          "description": "Hang closing bracket instead of matching indentation of opening bracket's line.",
+          "type": "boolean",
+          "default": false,
+          "order": 6
+        }
+      }
     }
   },
   "dependencies": {

--- a/spec/linter-flake8-spec.js
+++ b/spec/linter-flake8-spec.js
@@ -229,7 +229,7 @@ describe('The flake8 provider for Linter', () => {
     });
 
     it('works with a single builtin', async () => {
-      atom.config.set('linter-flake8.builtins', ['bar']);
+      atom.config.set('linter-flake8.flake8.builtins', ['bar']);
       const messages = await lint(editor);
       expect(messages.length).toBe(1);
 
@@ -241,7 +241,7 @@ describe('The flake8 provider for Linter', () => {
     });
 
     it('works with multiple builtins', async () => {
-      atom.config.set('linter-flake8.builtins', ['bar', 'foo_bar']);
+      atom.config.set('linter-flake8.flake8.builtins', ['bar', 'foo_bar']);
       const messages = await lint(editor);
       expect(messages.length).toBe(0);
     });

--- a/spec/make-spy.js
+++ b/spec/make-spy.js
@@ -1,0 +1,22 @@
+'use babel';
+
+export default (returnValue) => {
+  // This will be a 2d array: list of param lists
+  // for each time it was called.
+  const calledWith = [];
+
+  const call = (...passedArgs) => {
+    // Save all the params received to exposed local var
+    calledWith.push(passedArgs);
+    // Return value provided on spy init
+    return returnValue === undefined
+      ? 'called spy'
+      : returnValue;
+  };
+
+  return {
+    call,
+    calledWith,
+    called: () => Boolean(calledWith.length),
+  };
+};

--- a/spec/migrate-config-options-spec.js
+++ b/spec/migrate-config-options-spec.js
@@ -1,0 +1,37 @@
+'use babel';
+
+import migrateConfigOptions from '../lib/migrate-config-options';
+import makeSpy from './make-spy';
+
+describe('migrateConfigOptions()', () => {
+  it('calls the migrate functions of objects in a proided migrations array', () => {
+    const migrateSpy = makeSpy();
+    const migrations = [{ migrate: migrateSpy.call }];
+    migrateConfigOptions(migrations);
+    expect(migrateSpy.called()).toEqual(true);
+  });
+
+  it('provides the linter-flake8 config to migrate functions', () => {
+    atom.config.set('linter-flake8.oldSetting', true);
+    const migrateSpy = makeSpy();
+    const migrations = [{ migrate: migrateSpy.call }];
+    migrateConfigOptions(migrations);
+    expect(migrateSpy.calledWith[0][0]).toEqual(atom.config.get('linter-flake8'));
+  });
+
+  it('moves configs using `moves` array in a provided migrations array', () => {
+    atom.config.set('linter-flake8.oldSetting', true);
+    const migrations = [{
+      moves: [{
+        old: 'oldSetting',
+        new: 'newSetting',
+      }],
+    }];
+    migrateConfigOptions(migrations);
+    const oldSetting = atom.config.get('linter-flake8.oldSetting');
+    const newSetting = atom.config.get('linter-flake8.newSetting');
+    console.log({ oldSetting, newSetting });
+    expect(oldSetting).toEqual(undefined);
+    expect(newSetting).toEqual(true);
+  });
+});


### PR DESCRIPTION
Flake8 is capable of correctly loading the config from coexisting default files. Explicitly passing files from linter-flake8 overrides this behavior.

Fixes #554.