### PR TITLE
Improve parseRegex

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -24,7 +24,7 @@ function loadDeps() {
 }
 
 // Local variables
-const parseRegex = /(\d+):(\d+):\s(([A-Z])\d{2,3})\s+(.*)/g;
+const parseRegex = /(\d+):(\d+):\s(([A-Z]{1,4})\d{2,3}):?\s+(.*)/g;
 const execPathVersions = new Map();
 
 const applySubstitutions = (givenExecPath, projDir) => {


### PR DESCRIPTION
Flake8 itself doesn't have any limitations for the error code format. On practice, some plugins have longer than 1 letter in the error code: `WPS`, `DAG`, `DEAL`. The reason is simple: now we have more flake8 plugins than ASCII uppercase letters :upside_down_face:

The PR updates `parseRegex` to match from 1 to 4 letters in the code instead of only 1.

Also, some plugins have `:` in the error message after the code. The PR handles this case as well.

Close #720